### PR TITLE
fixed: returns back to the register after form submission

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
@@ -102,7 +102,7 @@ public class HivProfileActivity extends CoreHivProfileActivity
         intent.putExtra(org.smartregister.chw.hiv.util.Constants.ActivityPayload.ACTION, Constants.ActivityPayloadType.FOLLOW_UP_VISIT);
         intent.putExtra(org.smartregister.chw.hiv.util.Constants.ActivityPayload.USE_DEFAULT_NEAT_FORM_LAYOUT, false);
 
-        activity.startActivityForResult(intent, org.smartregister.chw.anc.util.Constants.REQUEST_CODE_HOME_VISIT);
+        activity.startActivityForResult(intent, CoreConstants.ProfileActivityResults.CHANGE_COMPLETED);
     }
 
     @Override


### PR DESCRIPTION
After follow-up form submission, the CBHS clients list is returned