### PR TITLE
fixed: made the visibility condition for other location more foolproof

### DIFF
--- a/opensrp-chw/src/ba/assets/rule/hiv_followup_form_rules.yml
+++ b/opensrp-chw/src/ba/assets/rule/hiv_followup_form_rules.yml
@@ -149,7 +149,7 @@ actions:
 name: "client_moved_location_other_visibility"
 description: "client_moved_location visibility"
 priority: 1
-condition: "client_moved_location.value == 'Other'  "
+condition: "client_moved_location.value == 'Other' && (registration_or_followup_status.value == 'Client has relocated to another location' || registration_or_followup_status.value == 'Amehamishiwa mahali pengine')"
 actions:
   - "client_moved_location_other_visibility = true"
 


### PR DESCRIPTION
There was a bug when selecting "other" location on the moved to facility list. 
The other location text field appears but in the case where the person selects another client status the other location text field doesn't leave.
Made fixes for this in the form rules and made it more verbose