### PR TITLE
Fix/having single source cbhs forms

### DIFF
--- a/opensrp-chw/src/main/AndroidManifest.xml
+++ b/opensrp-chw/src/main/AndroidManifest.xml
@@ -292,6 +292,10 @@
             android:label="@string/upcoming_services"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity
+            android:name=".activity.CbhsUpcomingServiceActivity"
+            android:label="@string/upcoming_services"
+            android:theme="@style/ChwTheme.NoActionBar" />
+        <activity
             android:name=".activity.ChwReferralDetailsViewActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/CbhsUpcomingServiceActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/CbhsUpcomingServiceActivity.java
@@ -1,0 +1,23 @@
+package org.smartregister.chw.activity;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import org.smartregister.chw.anc.domain.MemberObject;
+import org.smartregister.chw.anc.presenter.BaseAncUpcomingServicesPresenter;
+import org.smartregister.chw.anc.util.Constants;
+import org.smartregister.chw.core.activity.CoreHivUpcomingServicesActivity;
+import org.smartregister.chw.interactor.CbhsUpcomingServicesInteractor;
+
+public class CbhsUpcomingServiceActivity extends CoreHivUpcomingServicesActivity {
+    public static void startMe(Activity activity, MemberObject memberObject) {
+        Intent intent = new Intent(activity, CbhsUpcomingServiceActivity.class);
+        intent.putExtra(Constants.ANC_MEMBER_OBJECTS.MEMBER_PROFILE_OBJECT, memberObject);
+        activity.startActivity(intent);
+    }
+
+    @Override
+    public void initializePresenter() {
+        presenter = new BaseAncUpcomingServicesPresenter(memberObject, new CbhsUpcomingServicesInteractor(), this);
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
@@ -93,19 +93,13 @@ public class HivProfileActivity extends CoreHivProfileActivity
 
         HivMemberObject hivMemberObject = HivDao.getMember(baseEntityID);
         JSONObject formJsonObject;
+        formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(activity, org.smartregister.chw.util.Constants.CBHSJsonForms.getCbhsFollowupForm());
 
-        if (hivMemberObject.getCtcNumber().isEmpty()) {
-            if (hivMemberObject.getGender().equalsIgnoreCase("Female")) {
-                formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(activity, org.smartregister.chw.util.Constants.JSON_FORM.getFemaleHivFollowupVisit());
-            } else {
-                formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(activity, CoreConstants.JSON_FORM.getMaleHivFollowupVisit());
-            }
-        } else {
-            if (hivMemberObject.getGender().equalsIgnoreCase("Female")) {
-                formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(activity, org.smartregister.chw.util.Constants.JSON_FORM.getFemaleHivFollowupVisitForClientsWithCtcNumbers());
-            } else {
-                formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(activity, CoreConstants.JSON_FORM.getMaleHivFollowupVisitForClientsWithCtcNumbers());
-            }
+        if (!hivMemberObject.getCtcNumber().isEmpty()) {
+            JSONArray steps = formJsonObject.getJSONArray("steps");
+            JSONObject step = steps.getJSONObject(0);
+            JSONArray fields = step.getJSONArray("fields");
+            removeField(fields, "client_hiv_status_after_testing");
         }
 
         intent.putExtra(org.smartregister.chw.hiv.util.Constants.ActivityPayload.JSON_FORM, initializeHealthFacilitiesList(formJsonObject).toString());
@@ -113,6 +107,22 @@ public class HivProfileActivity extends CoreHivProfileActivity
         intent.putExtra(org.smartregister.chw.hiv.util.Constants.ActivityPayload.USE_DEFAULT_NEAT_FORM_LAYOUT, false);
 
         activity.startActivityForResult(intent, CoreConstants.ProfileActivityResults.CHANGE_COMPLETED);
+    }
+
+    private static void removeField(JSONArray fields, String fieldName) throws JSONException {
+        int position = 0;
+        boolean found = false;
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (field.getString("name").equalsIgnoreCase(fieldName)) {
+                position = i;
+                found = true;
+                break;
+            }
+        }
+        if (found) {
+            fields.remove(position);
+        }
     }
 
     public static void startHivCommunityFollowupFeedbackActivity(Activity activity, String baseEntityID) throws JSONException {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
@@ -33,6 +33,7 @@ import org.smartregister.chw.core.task.RunnableTask;
 import org.smartregister.chw.core.utils.ChwNotificationUtil;
 import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.custom_view.HivFloatingMenu;
+import org.smartregister.chw.dao.ChwCBHSDao;
 import org.smartregister.chw.hiv.activity.BaseHivFormsActivity;
 import org.smartregister.chw.hiv.dao.HivDao;
 import org.smartregister.chw.hiv.domain.HivMemberObject;
@@ -100,6 +101,13 @@ public class HivProfileActivity extends CoreHivProfileActivity
             JSONObject step = steps.getJSONObject(0);
             JSONArray fields = step.getJSONArray("fields");
             removeField(fields, "client_hiv_status_after_testing");
+        }
+
+        if(ChwCBHSDao.tbStatusAfterTestingDone(baseEntityID)){
+            JSONArray steps = formJsonObject.getJSONArray("steps");
+            JSONObject step = steps.getJSONObject(0);
+            JSONArray fields = step.getJSONArray("fields");
+            removeField(fields, "client_tb_status_after_testing");
         }
 
         intent.putExtra(org.smartregister.chw.hiv.util.Constants.ActivityPayload.JSON_FORM, initializeHealthFacilitiesList(formJsonObject).toString());

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HivProfileActivity.java
@@ -368,7 +368,7 @@ public class HivProfileActivity extends CoreHivProfileActivity
 
     @Override
     public void openUpcomingServices() {
-        CoreHivUpcomingServicesActivity.startMe(this, HivUtil.toMember(getHivMemberObject()));
+        CbhsUpcomingServiceActivity.startMe(this, HivUtil.toMember(getHivMemberObject()));
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwCBHSDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwCBHSDao.java
@@ -1,0 +1,18 @@
+package org.smartregister.chw.dao;
+
+import org.smartregister.dao.AbstractDao;
+
+import java.util.List;
+
+public class ChwCBHSDao extends AbstractDao {
+    public static boolean tbStatusAfterTestingDone(String baseEntityID) {
+        String sql = "Select client_tb_status_after_testing from ec_cbhs_register where base_entity_id = '" + baseEntityID + "'";
+
+        DataMap<String> dataMap = cursor -> getCursorValue(cursor, "client_tb_status_after_testing");
+        List<String> res = readData(sql, dataMap);
+
+        if (res != null && res.size() > 0 && res.get(0) != null)
+            return !res.get(0).equalsIgnoreCase("unknown");
+        return false;
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwCBHSDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwCBHSDao.java
@@ -2,7 +2,15 @@ package org.smartregister.chw.dao;
 
 import org.smartregister.dao.AbstractDao;
 
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
+
+import timber.log.Timber;
 
 public class ChwCBHSDao extends AbstractDao {
     public static boolean tbStatusAfterTestingDone(String baseEntityID) {
@@ -14,5 +22,29 @@ public class ChwCBHSDao extends AbstractDao {
         if (res != null && res.size() > 0 && res.get(0) != null)
             return !res.get(0).equalsIgnoreCase("unknown");
         return false;
+    }
+
+    public static Date getNextVisitDate(String baseEntityId){
+        String sql = "Select next_appointment_date from ec_cbhs_register where base_entity_id = '" + baseEntityId + "'";
+
+        DataMap<String> dataMap = cursor -> getCursorValue(cursor, "next_appointment_date");
+        List<String> res = readData(sql, dataMap);
+
+        if (res != null && res.size() > 0 && res.get(0) != null){
+            Calendar cal = Calendar.getInstance();
+            try{
+                cal.setTimeInMillis(new BigDecimal(res.get(0)).longValue());
+            }catch (Exception e){
+                //NEEDED FOR THE ISSUE IN SOME TABLETS FAILING TO CREATE A TIMESTAMP
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+                try {
+                    cal.setTime(sdf.parse(res.get(0)));
+                } catch (ParseException parseException) {
+                    Timber.e(parseException);
+                }
+            }
+            return new Date(cal.getTimeInMillis());
+        }
+        return null;
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/CbhsUpcomingServicesInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/CbhsUpcomingServicesInteractor.java
@@ -4,17 +4,16 @@ import android.content.Context;
 
 import org.jeasy.rules.api.Rules;
 import org.smartregister.chw.anc.domain.MemberObject;
-import org.smartregister.chw.anc.domain.Visit;
 import org.smartregister.chw.anc.interactor.BaseAncUpcomingServicesInteractor;
 import org.smartregister.chw.anc.model.BaseUpcomingService;
 import org.smartregister.chw.core.R;
 import org.smartregister.chw.core.application.CoreChwApplication;
-import org.smartregister.chw.core.rule.HivFollowupRule;
 import org.smartregister.chw.core.utils.CoreConstants;
-import org.smartregister.chw.core.utils.HomeVisitUtil;
+import org.smartregister.chw.dao.ChwCBHSDao;
 import org.smartregister.chw.hiv.dao.HivDao;
 import org.smartregister.chw.hiv.domain.HivAlertObject;
-import org.smartregister.chw.hiv.util.Constants;
+import org.smartregister.chw.rule.CbhsFollowupRule;
+import org.smartregister.chw.util.ChwHomeVisitUtil;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -50,15 +49,11 @@ public class CbhsUpcomingServicesInteractor extends BaseAncUpcomingServicesInter
                 hiv_date = hiv.getHivStartDate();
             }
         }
-        Date lastVisitDate = null;
-        Visit lastVisit;
-        Date hivDate = new Date(new BigDecimal(hiv_date).longValue());
-        lastVisit = HivDao.getLatestVisit(memberObject.getBaseEntityId(), Constants.EventType.FOLLOW_UP_VISIT);
-        if (lastVisit != null) {
-            lastVisitDate = lastVisit.getDate();
-        }
 
-        HivFollowupRule alertRule = HomeVisitUtil.getHivVisitStatus(lastVisitDate, hivDate);
+        Date hivDate = new Date(new BigDecimal(hiv_date).longValue());
+        Date nextVisitDate = ChwCBHSDao.getNextVisitDate(memberObject.getBaseEntityId());
+
+        CbhsFollowupRule alertRule = ChwHomeVisitUtil.getCBHSVisitStatus(nextVisitDate, hivDate);
         serviceDueDate = alertRule.getDueDate();
         serviceOverDueDate = alertRule.getOverDueDate();
         serviceName = context.getString(R.string.cbhs_follow_up_visit);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/rule/CbhsFollowupRule.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/rule/CbhsFollowupRule.java
@@ -4,7 +4,6 @@ import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
 import org.smartregister.chw.core.rule.HivFollowupRule;
-import org.smartregister.chw.core.rule.ICommonRule;
 import org.smartregister.chw.core.utils.CoreConstants;
 
 import java.text.SimpleDateFormat;

--- a/opensrp-chw/src/main/java/org/smartregister/chw/rule/CbhsFollowupRule.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/rule/CbhsFollowupRule.java
@@ -1,0 +1,95 @@
+package org.smartregister.chw.rule;
+
+import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.LocalDate;
+import org.smartregister.chw.core.rule.HivFollowupRule;
+import org.smartregister.chw.core.rule.ICommonRule;
+import org.smartregister.chw.core.utils.CoreConstants;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class CbhsFollowupRule extends HivFollowupRule {
+    public static final String RULE_KEY = "hivFollowupRule";
+    private String visitID;
+    private DateTime hivDate;
+    private DateTime dueDate;
+    private DateTime overDueDate;
+    private DateTime nextVisitDate;
+    private DateTime expiryDate;
+    private int daysDifference;
+
+    public CbhsFollowupRule(Date hivDate, Date nextVisitDate) {
+        super(hivDate, nextVisitDate);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+        this.hivDate = hivDate != null ? new DateTime(sdf.format(hivDate)) : null;
+        this.nextVisitDate = nextVisitDate == null ? null : new DateTime(nextVisitDate);
+        isValid();
+    }
+
+    public String getVisitID() {
+        return visitID;
+    }
+
+    public void setVisitID(String visitID) {
+        this.visitID = visitID;
+    }
+
+    public int getDaysDifference() {
+        return daysDifference;
+    }
+
+    public boolean isValid() {
+        if (nextVisitDate != null) {
+            this.dueDate = nextVisitDate.plusDays(0);
+            this.overDueDate = nextVisitDate.plusDays(28);
+            this.expiryDate = nextVisitDate.plusDays(365);
+        } else {
+            this.dueDate = hivDate.plusDays(28);
+            this.overDueDate = hivDate.plusDays(35);
+            this.expiryDate = hivDate.plusDays(365);
+        }
+
+        daysDifference = Days.daysBetween(new DateTime(), new DateTime(dueDate)).getDays();
+        return true;
+    }
+
+    public Date getDueDate() {
+        return dueDate != null ? dueDate.toDate() : null;
+    }
+
+    public Date getOverDueDate() {
+        return overDueDate != null ? overDueDate.toDate() : null;
+    }
+
+    public Date getExpiryDate() {
+        return expiryDate != null ? expiryDate.toDate() : null;
+    }
+
+    @Override
+    public String getRuleKey() {
+        return "hivFollowupRule";
+    }
+
+    @Override
+    public String getButtonStatus() {
+        DateTime currentDate = new DateTime(new LocalDate().toDate());
+        DateTime lastVisit = nextVisitDate;
+
+        if (currentDate.isBefore(expiryDate)) {
+            if ((currentDate.isAfter(overDueDate) || currentDate.isEqual(overDueDate)))
+                return CoreConstants.VISIT_STATE.OVERDUE;
+            if ((currentDate.isAfter(dueDate) || currentDate.isEqual(dueDate)) && currentDate.isBefore(overDueDate))
+                return CoreConstants.VISIT_STATE.DUE;
+            if (lastVisit != null && currentDate.isEqual(lastVisit))
+                return CoreConstants.VISIT_STATE.VISIT_DONE;
+            return CoreConstants.VISIT_STATE.NOT_DUE_YET;
+
+        }
+        return CoreConstants.VISIT_STATE.EXPIRED;
+    }
+
+
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/task/HivVisitScheduler.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/task/HivVisitScheduler.java
@@ -1,14 +1,14 @@
 package org.smartregister.chw.task;
 
-import org.smartregister.chw.anc.domain.Visit;
 import org.smartregister.chw.application.ChwApplication;
 import org.smartregister.chw.core.contract.ScheduleTask;
 import org.smartregister.chw.core.domain.BaseScheduleTask;
-import org.smartregister.chw.core.rule.HivFollowupRule;
 import org.smartregister.chw.core.utils.CoreConstants;
-import org.smartregister.chw.core.utils.HomeVisitUtil;
+import org.smartregister.chw.dao.ChwCBHSDao;
 import org.smartregister.chw.hiv.dao.HivDao;
 import org.smartregister.chw.hiv.domain.HivMemberObject;
+import org.smartregister.chw.rule.CbhsFollowupRule;
+import org.smartregister.chw.util.ChwHomeVisitUtil;
 
 import java.util.Date;
 import java.util.List;
@@ -26,13 +26,12 @@ public class HivVisitScheduler extends BaseTaskExecutor {
 
         BaseScheduleTask baseScheduleTask = prepareNewTaskObject(baseEntityID);
         HivMemberObject hivMemberObject = HivDao.getMember(baseEntityID);
-        Visit lastVisit = HivDao.getLatestVisit(baseEntityID, org.smartregister.chw.hiv.util.Constants.EventType.FOLLOW_UP_VISIT);
-        Date lastVisitDate = lastVisit != null ? lastVisit.getDate() : null;
-        HivFollowupRule hivFollowupRule = HomeVisitUtil.getHivVisitStatus(lastVisitDate, hivMemberObject.getHivRegistrationDate());
+        Date nextVisitDate = ChwCBHSDao.getNextVisitDate(baseEntityID);
+        CbhsFollowupRule cbhsFollowupRule = ChwHomeVisitUtil.getCBHSVisitStatus(nextVisitDate, hivMemberObject.getHivRegistrationDate());
 
-        baseScheduleTask.setScheduleDueDate(hivFollowupRule.getDueDate());
-        baseScheduleTask.setScheduleExpiryDate(hivFollowupRule.getExpiryDate());
-        baseScheduleTask.setScheduleOverDueDate(hivFollowupRule.getOverDueDate());
+        baseScheduleTask.setScheduleDueDate(cbhsFollowupRule.getDueDate());
+        baseScheduleTask.setScheduleExpiryDate(cbhsFollowupRule.getExpiryDate());
+        baseScheduleTask.setScheduleOverDueDate(cbhsFollowupRule.getOverDueDate());
 
         return toScheduleList(baseScheduleTask);
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwHomeVisitUtil.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwHomeVisitUtil.java
@@ -1,0 +1,17 @@
+package org.smartregister.chw.util;
+
+import org.smartregister.chw.core.application.CoreChwApplication;
+import org.smartregister.chw.core.utils.CoreConstants;
+import org.smartregister.chw.core.utils.HomeVisitUtil;
+import org.smartregister.chw.rule.CbhsFollowupRule;
+
+import java.util.Date;
+
+public class ChwHomeVisitUtil extends HomeVisitUtil {
+
+    public static CbhsFollowupRule getCBHSVisitStatus(Date lastVisitDate, Date hivDate) {
+        CbhsFollowupRule cbhsFollowupRule = new CbhsFollowupRule(hivDate, lastVisitDate);
+        CoreChwApplication.getInstance().getRulesEngineHelper().getHivRule(cbhsFollowupRule, CoreConstants.RULE_FILE.HIV_FOLLOW_UP_VISIT);
+        return cbhsFollowupRule;
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -77,6 +77,14 @@ public class Constants extends CoreConstants {
         String ReferralFormId = "referral_form_id";
     }
 
+    public static class CBHSJsonForms {
+        private static final String CBHS_FOLLOWUP_FORM = "cbhs_followup_form";
+
+        public static String getCbhsFollowupForm() {
+            return CBHS_FOLLOWUP_FORM;
+        }
+    }
+
     public static final class JsonForm{
         private static final String PARTNER_REGISTRATION_FORM = "male_partner_registration_form";
         private static final String PMTCT_COMMUNITY_FOLLOWUP_FEEDBACK = "pmtct_community_followup_feedback";

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -2804,6 +2804,14 @@
           }
         },
         {
+          "column_name": "client_tb_status_after_testing",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.formSubmissionField",
+            "concept": "client_tb_status_after_testing"
+          }
+        },
+        {
           "column_name": "hiv_registration_date",
           "type": "Event",
           "data_type": "date",

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -2812,6 +2812,14 @@
           }
         },
         {
+          "column_name": "next_appointment_date",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.formSubmissionField",
+            "concept": "next_appointment_date"
+          }
+        },
+        {
           "column_name": "hiv_registration_date",
           "type": "Event",
           "data_type": "date",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/cbhs_followup_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/cbhs_followup_form.json
@@ -1,0 +1,1171 @@
+{
+  "form": "CBHS Follow-up form",
+  "count": "1",
+  "encounter_type": "CBHS Followup",
+  "entity_id": "",
+  "relational_id": "",
+  "rules_file": "rule/cbhs_followup_form_rules.yml",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": "",
+    "look_up": {
+      "entity_id": "",
+      "value": ""
+    }
+  },
+  "steps": [
+    {
+      "title": "Fomu ya kumtembelea mgonjwa wa VVU",
+      "fields": [
+        {
+          "name": "registration_or_followup_status",
+          "type": "spinner",
+          "properties": {
+            "text": "Hali ya ufuatiliaji"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "registration_or_followup_status",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "new_client",
+              "text": "Mpya",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "new_client",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "continuing_with_services",
+              "text": "Anaendelea na Huduma.",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "continuing_with_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "deceased",
+              "text": "Amefariki",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "deceased",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_not_found",
+              "text": "Hapatikani",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_not_found",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_relocated_to_another_location",
+              "text": "Amehamishiwa mahali pengine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_relocated_to_another_location",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_has_moved",
+              "text": "Amehama",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_has_moved",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_has_absconded",
+              "text": "Amejitoa",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_has_absconded",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_continues_with_clinic_from_elsewhere",
+              "text": "Anaendelea na huduma kutoka sehemu nyingine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_continues_with_clinic_from_elsewhere",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "completed_and_qualified_from_the_services",
+              "text": "Amemaliza huduma",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "completed_and_qualified_from_the_services",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua hali ya ufwatiliaji",
+          "dependent_calculations": [
+            "hiv_followup_visit_date"
+          ]
+        },
+        {
+          "name": "client_hiv_status_after_testing",
+          "type": "spinner",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_hiv_status_after_testing",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "text": "Hali ya maambukizi ya VVU baada ya kipimo"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Haitambuliki",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "unknown",
+              "text": "Haijulikani",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "unknown",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "positive",
+              "text": "Chanya",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "positive",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "negative",
+              "text": "Hasi",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "negative",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua moja",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_tb_status_after_testing",
+          "type": "spinner",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_tb_status_after_testing",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "text": "Hali ya maambukizi ya Kifua Kikuu baada ya kipimo"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Haitambuliki",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "unknown",
+              "text": "Haijulikani",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "unknown",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "positive",
+              "text": "Chanya",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "positive",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "negative",
+              "text": "Hasi",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "negative",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua moja",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "ctc_number",
+          "type": "masked_edit_text",
+          "properties": {
+            "hint": "Namba ya CTC mfano: 12-34-5678-912345",
+            "type": "Namba ya CTC mfano: 12-34-5678-912345",
+            "mask": "##-##-####-######",
+            "mask_hint": "12345678912345",
+            "input_type": "number",
+            "allowed_chars": "0123456789"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "ctc_number",
+            "openmrs_entity_parent": ""
+          },
+          "validation": [
+            {
+              "condition": "value.matches(\"(\\\\d{2}-\\\\d{2}-\\\\d{4}-\\\\d{6})?\")",
+              "message": "Namba ya CTC iwe kwenye mfumo wa (XXXX-XX-XX-XXX)."
+            }
+          ],
+          "required_status": "yes:Tafadhali jaza namba ya CTC",
+          "subjects": "client_hiv_status_after_testing:text"
+        },
+        {
+          "name": "health_problem",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Matatizo ya kijamii/kitabibu ya Mteja"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "problem"
+          },
+          "options": [
+            {
+              "name": "general_body_malaise",
+              "text": "General Body Malaise",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "general_body_malaise",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "chest_pain",
+              "text": "Chest Pain",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "chest_pain",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "skin_infection",
+              "text": "Skin Infection",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "skin_infection",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "loss_of_appetite",
+              "text": "Loss of Appetite",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "loss_of_appetite",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "malnutrition",
+              "text": "Malnutrition",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "malnutrition",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "fever",
+              "text": "Fever",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "fever",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "jaundice",
+              "text": "Jaundice",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "jaundice",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "headache",
+              "text": "Headache",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "headache",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "coughing",
+              "text": "Coughing",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "coughing",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "altered_mental_status",
+              "text": "Altered Mental Status",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "altered_mental_status",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "convulsion",
+              "text": "Convulsion",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "convulsion",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "loss_of_consciousness",
+              "text": "Loss of Consciousness",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "loss_of_consciousness",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "drugs_side_effects",
+              "text": "Drugs Side Effects",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "drugs_side_effects",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_health_problems",
+              "text": "Matatizo mengine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_health_problems",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hana tatizo",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua matatizo ya kijamii/kitabibu ya Mteja",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "health_problem_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Matatizo mengine ya kitabibu ya Mteja",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "health_problem_other",
+            "openmrs_entity_parent": "health_problem"
+          },
+          "required_status": "true:Tafadhali jaza matatizo mengine",
+          "subjects": "health_problem:map"
+        },
+        {
+          "name": "prompt_for_health_challenges",
+          "type": "toast_notification",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "prompt_for_health_challenges",
+            "openmrs_entity_parent": "health_problem"
+          },
+          "properties": {
+            "notification_type": "error",
+            "dismissible": "no",
+            "text": "Refer to health facility for further management"
+          },
+          "subjects": "health_problem:map"
+        },
+        {
+          "name": "social_problem",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick Psychosocial challenges faced by the Client."
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "social_problem"
+          },
+          "options": [
+            {
+              "name": "stigma_and_discriminations",
+              "text": "Stigma and Discriminations",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "stigma_and_discriminations",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "food_insecurity",
+              "text": "Food insecurity",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "food_insecurity",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "lack_disclosure",
+              "text": "Lack disclosure",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "lack_disclosure",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "transport_issues_for_attending_ctc",
+              "text": "Transport issues while attending CTC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "transport_issues_for_attending_ctc",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "economic_constraints",
+              "text": "Economic constraints",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "economic_constraints",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "gbv_and_vac",
+              "text": "GBV and VAC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "gbv_and_vac",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "hard_to_reach_areas",
+              "text": "Hard to reach areas",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hard_to_reach_areas",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_social_problems",
+              "text": "Matatizo mengine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_social_problems",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hana tatizo",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua matatizo ya kijamii/kitabibu ya Mteja",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "social_problem_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Psychosocial Challenges",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "social_problem_other",
+            "openmrs_entity_parent": "social_problem"
+          },
+          "required_status": "true:Please specify other psychosocial problems faced",
+          "subjects": "social_problem:map"
+        },
+        {
+          "name": "supplies_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Vifaa/Commodities vilivyotolewa"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "supplies_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "hiv_self_test_kits",
+              "text": "HIV Self Testing Kits",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hiv_self_test_kits",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "sanitizers",
+              "text": "Sanitizers",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "sanitizers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "face_masks",
+              "text": "Face masks",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "face_masks",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "condoms",
+              "text": "Condoms",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "condoms",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "water_disinfectant",
+              "text": "Water disinfectants",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "water_disinfectant",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_supplies",
+              "text": "Vifaa vingine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_supplies",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hakuna",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali chagua kifaa/commodities vilivyotolewa",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "supplies_provided_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Vifaa/Commodities vingine",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "supplies_provided_other",
+            "openmrs_entity_parent": "supplies_provided"
+          },
+          "required_status": "true:Tafadhali jaza vifaa/commodities vingine vilivyotolewa",
+          "subjects": "supplies_provided:map"
+        },
+        {
+          "name": "medicine_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Dawa zilizotolewa"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "medicine_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "paracetamol",
+              "text": "Paracetamol",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "paracetamol",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ors",
+              "text": "ORS",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ors",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hakuna",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please choose medicine given",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "hiv_services_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Huduma za CBHS zilizotolewa"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hiv_services_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "hiv_education",
+              "text": "HIV Education",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hiv_education",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "pretest_information",
+              "text": "Pretest Information",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "pretest_information",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ipc",
+              "text": "IPC (Uzuiaji wa uambukizo katika Jamii)",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ipc",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "adherence_counselling",
+              "text": "Adherence Counselling",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "adherence_counselling",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "gbv_vac_screening",
+              "text": "Screening of GBV and VAC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "gbv_vac_screening",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "tb_sti_screening",
+              "text": "TB and STI Screening",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "tb_sti_screening",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "referral_and_linkage",
+              "text": "Referral and Linkage",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "referral_and_linkage",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "self_test_information",
+              "text": "Information and how to use self test",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "self_test_information",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "kvp_services",
+              "text": "KVP Services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "kvp_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_hiv_services",
+              "text": "Huduma nyingine za UKIMWI katika jamii",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_hiv_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hamna huduma iliyotolewa",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali jaza huduma za CBHS zilizotolewa",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "hiv_services_provided_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Huduma nyingnie za CBHS zilizotolewa",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hiv_services_provided_other",
+            "openmrs_entity_parent": "hiv_services_provided"
+          },
+          "required_status": "true:Tafadhali jaza huduma nyingine za CBHS zilizotolewa",
+          "subjects": "hiv_services_provided:map"
+        },
+        {
+          "name": "referrals_issued_to_other_services",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick referrals issued to the Client for other services other than Medical Services"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_issued_to_other_services"
+          },
+          "options": [
+            {
+              "name": "legal_services",
+              "text": "Huduma ya kisheria",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "legal_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "support_groups",
+              "text": "Msaada wa kisaikolojia kutoka kwenye makundi",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "support_groups",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ovc_services",
+              "text": "Huduma za watoto yatima na wanaoishi kwenye mazingira magumu",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ovc_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "elderly_centers",
+              "text": "Vituo vya wazee",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "elderly_centers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_referrals",
+              "text": "Rufaa nyingine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_referrals",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hakuna",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify the referrals issued",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "referrals_issued_to_other_services_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Rufaa nyingine zilizotolewa",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_issued_to_other_services_other",
+            "openmrs_entity_parent": "referrals_issued_to_other_services"
+          },
+          "required_status": "true:Please specify other Referrals Issued",
+          "subjects": "referrals_issued_to_other_services:map"
+        },
+        {
+          "name": "referrals_to_other_services_completed",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick Referrals to other services other than Medical Services Completed by the Client."
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_to_other_services_completed"
+          },
+          "options": [
+            {
+              "name": "legal_services",
+              "text": "Huduma ya kisheria",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "legal_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "support_groups",
+              "text": "Msaada wa kisaikolojia kutoka kwenye makundi",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "support_groups",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ovc_services",
+              "text": "Huduma za watoto yatima na wanaoishi kwenye mazingira magumu",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ovc_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "elderly_centers",
+              "text": "Vituo vya wazee",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "elderly_centers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_referrals",
+              "text": "Rufaa nyingine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_referrals",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hakuna",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify the referrals completed",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "referrals_to_other_services_completed_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Rufaa nyingine zilizokamilishwa na mteja",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_to_other_services_completed_other",
+            "openmrs_entity_parent": "referrals_to_other_services_completed"
+          },
+          "required_status": "true:Please specify other Referrals Completed",
+          "subjects": "referrals_to_other_services_completed:map"
+        },
+        {
+          "name": "state_of_therapy",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Hali ya Tiba na Matunzo (CTC)"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "state_of_therapy"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Haihusiki",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_but_not_began_medication",
+              "text": "Ameandikishwa CTC/PMTCT lakini hajaanza ARV",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_but_not_began_medication",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_and_uses_medication",
+              "text": "Ameandikishwa CTC/PMTCT na anatumia ARV",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_and_uses_medication",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "not_registered_in_ctc_clinic",
+              "text": "Hajaandikishwa CTC/PMTCT",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "not_registered_in_ctc_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_in_injection_drugs_users_clinic",
+              "text": "Registered in Injection Drugs Users Clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_in_injection_drugs_users_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_in_tb_clinic",
+              "text": "Registered in TB Clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_in_tb_clinic",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali jaza hali ya tiba na matunzo (CTC)",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "comments_remarks",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Comments and Remarks",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "comments_remarks",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "no"
+        },
+        {
+          "name": "next_appointment_date",
+          "type": "datetime_picker",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "next_appointment_date",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "hint": "Next Appointment Date",
+            "type": "date_picker",
+            "display_format": "dd/MM/yyyy",
+            "min_date": "today",
+            "max_date": "today+3m"
+          },
+          "required_status": "true:Please specify the next appointment date",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_moved_location",
+          "type": "spinner",
+          "properties": {
+            "text": "Chagua alipohamia",
+            "searchable": "Chagua alipohamia"
+          },
+          "options": [
+            {
+              "name": "Other",
+              "text": "Other",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "Other",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_moved_location",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "yes:Tafadhali chagua sehemu alipohamia",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_moved_location_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Andika alipohamia",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_moved_location",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "yes:Tafadhali andika alipohamia",
+          "subjects": "client_moved_location:text"
+        }
+      ]
+    }
+  ]
+}

--- a/opensrp-chw/src/nacp/assets/json.form/cbhs_followup_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/cbhs_followup_form.json
@@ -1,0 +1,1171 @@
+{
+  "form": "CBHS Follow-up form",
+  "count": "1",
+  "encounter_type": "CBHS Followup",
+  "entity_id": "",
+  "relational_id": "",
+  "rules_file": "rule/cbhs_followup_form_rules.yml",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": "",
+    "look_up": {
+      "entity_id": "",
+      "value": ""
+    }
+  },
+  "steps": [
+    {
+      "title": "CBHS Follow-up form",
+      "fields": [
+        {
+          "name": "registration_or_followup_status",
+          "type": "spinner",
+          "properties": {
+            "text": "Followup status"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "registration_or_followup_status",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "new_client",
+              "text": "New Client",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "new_client",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "continuing_with_services",
+              "text": "Continuing with services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "continuing_with_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "deceased",
+              "text": "Deceased",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "deceased",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_not_found",
+              "text": "Client not found",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_not_found",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_relocated_to_another_location",
+              "text": "Client has relocated to another location",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_relocated_to_another_location",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_has_moved",
+              "text": "Client has moved ",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_has_moved",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_has_absconded",
+              "text": "Client has absconded",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_has_absconded",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_continues_with_clinic_from_elsewhere",
+              "text": "Client continues with clinic from elsewhere",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "client_continues_with_clinic_from_elsewhere",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "completed_and_qualified_from_the_services",
+              "text": "Client has completed and qualified from the services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "completed_and_qualified_from_the_services",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please select the registration/followup status",
+          "dependent_calculations": [
+            "hiv_followup_visit_date"
+          ]
+        },
+        {
+          "name": "client_hiv_status_after_testing",
+          "type": "spinner",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_hiv_status_after_testing",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "text": "Client's HIV status after testing"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Not Applicable",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "unknown",
+              "text": "Unknown",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "unknown",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "positive",
+              "text": "Positive",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "positive",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "negative",
+              "text": "Negative",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "negative",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify client's hiv status",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_tb_status_after_testing",
+          "type": "spinner",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_tb_status_after_testing",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "text": "Client's TB status after testing"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Not Applicable",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "unknown",
+              "text": "Unknown",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "unknown",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "positive",
+              "text": "Positive",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "positive",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "negative",
+              "text": "Negative",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "negative",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify client's TB status",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "ctc_number",
+          "type": "masked_edit_text",
+          "properties": {
+            "hint": "CTC Number",
+            "type": "Clinic of Treatment and Care registration number (CTC Number)",
+            "mask": "##-##-####-######",
+            "mask_hint": "12345678912345",
+            "input_type": "number",
+            "allowed_chars": "0123456789"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "ctc_number",
+            "openmrs_entity_parent": ""
+          },
+          "validation": [
+            {
+              "condition": "value.matches(\"(\\\\d{2}-\\\\d{2}-\\\\d{4}-\\\\d{6})?\")",
+              "message": "Not a valid CTC Number."
+            }
+          ],
+          "required_status": "yes:Please specify client's CTC Number",
+          "subjects": "client_hiv_status_after_testing:text, registration_or_followup_status:map"
+        },
+        {
+          "name": "health_problem",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick Health Challenges faced by the Client."
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "problem"
+          },
+          "options": [
+            {
+              "name": "general_body_malaise",
+              "text": "General Body Malaise",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "general_body_malaise",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "chest_pain",
+              "text": "Chest Pain",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "chest_pain",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "skin_infection",
+              "text": "Skin Infection",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "skin_infection",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "loss_of_appetite",
+              "text": "Loss of Appetite",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "loss_of_appetite",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "malnutrition",
+              "text": "Malnutrition",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "malnutrition",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "fever",
+              "text": "Fever",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "fever",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "jaundice",
+              "text": "Jaundice",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "jaundice",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "headache",
+              "text": "Headache",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "headache",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "coughing",
+              "text": "Coughing",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "coughing",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "altered_mental_status",
+              "text": "Altered Mental Status",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "altered_mental_status",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "convulsion",
+              "text": "Convulsion",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "convulsion",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "loss_of_consciousness",
+              "text": "Loss of Consciousness",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "loss_of_consciousness",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "drugs_side_effects",
+              "text": "Drugs Side Effects",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "drugs_side_effects",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_health_problems",
+              "text": "Other Health Challenges",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_health_problems",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify client's problems",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "health_problem_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Health Problems",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "health_problem_other",
+            "openmrs_entity_parent": "health_problem"
+          },
+          "required_status": "true:Please specify other health problems",
+          "subjects": "health_problem:map"
+        },
+        {
+          "name": "prompt_for_health_challenges",
+          "type": "toast_notification",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "prompt_for_health_challenges",
+            "openmrs_entity_parent": "health_problem"
+          },
+          "properties": {
+            "notification_type": "error",
+            "dismissible": "no",
+            "text": "Refer to health facility for further management"
+          },
+          "subjects": "health_problem:map"
+        },
+        {
+          "name": "social_problem",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick Psychosocial challenges faced by the Client."
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "social_problem"
+          },
+          "options": [
+            {
+              "name": "stigma_and_discriminations",
+              "text": "Stigma and Discriminations",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "stigma_and_discriminations",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "food_insecurity",
+              "text": "Food insecurity",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "food_insecurity",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "lack_disclosure",
+              "text": "Lack disclosure",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "lack_disclosure",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "transport_issues_for_attending_ctc",
+              "text": "Transport issues while attending CTC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "transport_issues_for_attending_ctc",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "economic_constraints",
+              "text": "Economic constraints",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "economic_constraints",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "gbv_and_vac",
+              "text": "GBV and VAC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "gbv_and_vac",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "hard_to_reach_areas",
+              "text": "Hard to reach areas",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hard_to_reach_areas",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_social_problems",
+              "text": "Other Social Challenges",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_social_problems",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify client's problems",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "social_problem_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Psychosocial Challenges",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "social_problem_other",
+            "openmrs_entity_parent": "social_problem"
+          },
+          "required_status": "true:Please specify other psychosocial problems faced",
+          "subjects": "social_problem:map"
+        },
+        {
+          "name": "supplies_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Supplies/Commodities provided"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "supplies_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "hiv_self_test_kits",
+              "text": "HIV Self Testing Kits",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hiv_self_test_kits",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "sanitizers",
+              "text": "Sanitizers",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "sanitizers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "face_masks",
+              "text": "Face masks",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "face_masks",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "condoms",
+              "text": "Condoms",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "condoms",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "water_disinfectant",
+              "text": "Water disinfectants",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "water_disinfectant",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_supplies",
+              "text": "Other supplies",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_supplies",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please choose supplies/commodities given",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "supplies_provided_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Supplies/Commodities",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "supplies_provided_other",
+            "openmrs_entity_parent": "supplies_provided"
+          },
+          "required_status": "true:Please specify other supplies/commodities given",
+          "subjects": "supplies_provided:map"
+        },
+        {
+          "name": "medicine_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Medicines provided"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "medicine_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "paracetamol",
+              "text": "Paracetamol",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "paracetamol",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ors",
+              "text": "ORS",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ors",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please choose medicine given",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "hiv_services_provided",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "CBHS services provided"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hiv_services_provided",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "hiv_education",
+              "text": "HIV Education",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "hiv_education",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "pretest_information",
+              "text": "Pretest Information",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "pretest_information",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ipc",
+              "text": "IPC (Uzuiaji wa uambukizo katika Jamii)",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ipc",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "adherence_counselling",
+              "text": "Adherence Counselling",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "adherence_counselling",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "gbv_vac_screening",
+              "text": "Screening of GBV and VAC",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "gbv_vac_screening",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "tb_sti_screening",
+              "text": "TB and STI Screening",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "tb_sti_screening",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "referral_and_linkage",
+              "text": "Referral and Linkage",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "referral_and_linkage",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "self_test_information",
+              "text": "Information and how to use self test",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "self_test_information",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "kvp_services",
+              "text": "KVP Services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "kvp_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_hiv_services",
+              "text": "Other CBHS services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_hiv_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please fill the CBHS services provided",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "hiv_services_provided_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other CBHS Services Provided",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hiv_services_provided_other",
+            "openmrs_entity_parent": "hiv_services_provided"
+          },
+          "required_status": "true:Please specify other CBHS services provided",
+          "subjects": "hiv_services_provided:map"
+        },
+        {
+          "name": "referrals_issued_to_other_services",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick referrals issued to the Client for other services other than Medical Services"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_issued_to_other_services"
+          },
+          "options": [
+            {
+              "name": "legal_services",
+              "text": "Legal Services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "legal_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "support_groups",
+              "text": "Psycho Social Support groups",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "support_groups",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ovc_services",
+              "text": "OVC services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ovc_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "elderly_centers",
+              "text": "Elderly Centers ",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "elderly_centers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_referrals",
+              "text": "Other Referrals",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_referrals",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify the referrals issued",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "referrals_issued_to_other_services_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Referral Services Provided",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_issued_to_other_services_other",
+            "openmrs_entity_parent": "referrals_issued_to_other_services"
+          },
+          "required_status": "true:Please specify other Referrals Issued",
+          "subjects": "referrals_issued_to_other_services:map"
+        },
+        {
+          "name": "referrals_to_other_services_completed",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Pick Referrals to other services other than Medical Services Completed by the Client."
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_to_other_services_completed"
+          },
+          "options": [
+            {
+              "name": "legal_services",
+              "text": "Legal Services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "legal_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "support_groups",
+              "text": "Psycho Social Support groups",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "support_groups",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "ovc_services",
+              "text": " OVC services",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "ovc_services",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "elderly_centers",
+              "text": "Elderly Centers ",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "elderly_centers",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "other_referrals",
+              "text": "Other Referrals",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "other_referrals",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "None",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "none",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify the referrals completed",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "referrals_to_other_services_completed_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Other Referrals Completed",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referrals_to_other_services_completed_other",
+            "openmrs_entity_parent": "referrals_to_other_services_completed"
+          },
+          "required_status": "true:Please specify other Referrals Completed",
+          "subjects": "referrals_to_other_services_completed:map"
+        },
+        {
+          "name": "state_of_therapy",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "State of HIV Care and treatment"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "state_of_therapy"
+          },
+          "options": [
+            {
+              "name": "na",
+              "text": "Not Applicable",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "na",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_but_not_began_medication",
+              "text": "Registered in CTC/PMTCT clinic but hasn't begun ARV medication",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_but_not_began_medication",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_and_uses_medication",
+              "text": "Registered in CTC/PMTCT  clinic and uses ARV medication",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_and_uses_medication",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "not_registered_in_ctc_clinic",
+              "text": "Client is not registered in CTC/PMTCT clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "not_registered_in_ctc_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_in_injection_drugs_users_clinic",
+              "text": "Registered in Injection Drugs Users Clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_in_injection_drugs_users_clinic",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "registered_in_tb_clinic",
+              "text": "Registered in TB Clinic",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "registered_in_tb_clinic",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Please specify the state of HIV therapy",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "comments_remarks",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Comments and Remarks",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "comments_remarks",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "no"
+        },
+        {
+          "name": "next_appointment_date",
+          "type": "datetime_picker",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "next_appointment_date",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "hint": "Next Appointment Date",
+            "type": "date_picker",
+            "display_format": "dd/MM/yyyy",
+            "min_date": "today",
+            "max_date": "today+3m"
+          },
+          "required_status": "true:Please specify the next appointment date",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_moved_location",
+          "type": "spinner",
+          "properties": {
+            "text": "Choose Moved To Facility",
+            "searchable": "Choose moved to facility"
+          },
+          "options": [
+            {
+              "name": "Other",
+              "text": "Other",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "Other",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_moved_location",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "yes:Please select the moved to facility",
+          "subjects": "registration_or_followup_status:text"
+        },
+        {
+          "name": "client_moved_location_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Enter the other location",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "client_moved_location",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "yes:Please enter the moved to facility",
+          "subjects": "client_moved_location:text"
+        }
+      ]
+    }
+  ]
+}

--- a/opensrp-chw/src/nacp/assets/json.form/cbhs_followup_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/cbhs_followup_form.json
@@ -1121,8 +1121,7 @@
             "min_date": "today",
             "max_date": "today+3m"
           },
-          "required_status": "true:Please specify the next appointment date",
-          "subjects": "registration_or_followup_status:text"
+          "required_status": "true:Please specify the next appointment date"
         },
         {
           "name": "client_moved_location",

--- a/opensrp-chw/src/nacp/assets/rule/cbhs_followup_form_rules.yml
+++ b/opensrp-chw/src/nacp/assets/rule/cbhs_followup_form_rules.yml
@@ -13,6 +13,13 @@ condition: "registration_or_followup_status.value=='New Client' || registration_
 actions:
   - "client_hiv_status_after_testing_visibility =  true"
 ---
+name: "client_tb_status_after_testing_visibility"
+description: "client_hiv_status_after_testing visibility"
+priority: 1
+condition: "registration_or_followup_status.value=='New Client' || registration_or_followup_status.value=='Continuing with services' || registration_or_followup_status.value == 'Mpya' || registration_or_followup_status.value == 'Anaendelea na Huduma.'"
+actions:
+  - "client_tb_status_after_testing_visibility =  true"
+---
 name: "ctc_number_visibility"
 description: "ctc_number visibility"
 priority: 1


### PR DESCRIPTION
This pull request covers the following fixes:
- [x] Made the followup form for cbhs visits a single form called cbhs_followup_form, with an implementation to alter the form before loading it
- [x] Removed some of the questions for cbhs followups that include the client_condition and social_problem 
- [x] Added tb_status_after_testing question and tracking
- [x] Added implementation for the provider to set next visit and it is shown in the profile of the client in upcoming services.