### PR TITLE
fix: for chws with multiple villages to load referrals

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/fragment/LTFUReferralsRegisterFragment.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/fragment/LTFUReferralsRegisterFragment.java
@@ -15,7 +15,6 @@ import org.smartregister.configurableviews.model.View;
 import org.smartregister.cursoradapter.RecyclerViewPaginatedAdapter;
 import org.smartregister.domain.Task;
 import org.smartregister.family.util.DBConstants;
-import org.smartregister.repository.AllSharedPreferences;
 
 import java.util.Set;
 
@@ -44,10 +43,7 @@ public class LTFUReferralsRegisterFragment extends BaseReferralRegisterFragment 
 
     @Override
     protected String getMainCondition() {
-        AllSharedPreferences allSharedPreferences = Utils.getAllSharedPreferences();
-        String anm = allSharedPreferences.fetchRegisteredANM();
-        String currentLoaction = allSharedPreferences.fetchUserLocalityId(anm);
-        return "task.business_status = '" + CoreConstants.BUSINESS_STATUS.REFERRED + "' and ec_family_member_search.date_removed is null and task.group_id = '" + currentLoaction + "' ";
+        return "task.business_status = '" + CoreConstants.BUSINESS_STATUS.REFERRED + "' and ec_family_member_search.date_removed is null";
     }
 
     @Override


### PR DESCRIPTION
- [x] This fixes the assumption that a chw can operate on multiple villages in that ward, the only caveat is that chws in the same ward will share ltfu referrals